### PR TITLE
feat: add packagist downloads

### DIFF
--- a/src/Action/LoadPluginAction.php
+++ b/src/Action/LoadPluginAction.php
@@ -71,6 +71,7 @@ readonly class LoadPluginAction
             'license' => $version['license'][0] ?? 'UNKNOWN',
             'link' => $repositoryUrl,
             'availableVersion' => $version['version'],
+            'packagistDownloads' => $packagistData['package']['downloads']['total'] ?? 0,
         ];
 
         if ('' === trim($pluginData['manufacturer'])) {

--- a/src/Core/Framework/Plugin/AvailableOpensourcePlugin/AvailableOpensourcePluginDefinition.php
+++ b/src/Core/Framework/Plugin/AvailableOpensourcePlugin/AvailableOpensourcePluginDefinition.php
@@ -12,6 +12,7 @@ use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\ApiAware;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\PrimaryKey;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\Flag\Required;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\IdField;
+use Shopware\Core\Framework\DataAbstractionLayer\Field\IntField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\JsonField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\OneToOneAssociationField;
 use Shopware\Core\Framework\DataAbstractionLayer\Field\StringField;
@@ -53,6 +54,7 @@ class AvailableOpensourcePluginDefinition extends EntityDefinition
             (new StringField('license', 'license'))->addFlags(new Required()),
             (new StringField('link', 'link'))->addFlags(new Required()),
             (new StringField('available_version', 'availableVersion'))->addFlags(new Required()),
+            (new IntField('packagist_downloads', 'packagistDownloads'))->addFlags(new Required()),
             (new DateField('last_seen_at', 'lastSeenAt'))->addFlags(new Required()),
             (new DateField('last_commit_time', 'lastCommitTime'))->addFlags(new Required()),
 

--- a/src/Core/Framework/Plugin/AvailableOpensourcePlugin/AvailableOpensourcePluginEntity.php
+++ b/src/Core/Framework/Plugin/AvailableOpensourcePlugin/AvailableOpensourcePluginEntity.php
@@ -34,6 +34,8 @@ class AvailableOpensourcePluginEntity extends Entity
 
     protected string $availableVersion;
 
+    protected int $packagistDownloads;
+
     protected \DateTimeInterface $lastSeenAt;
 
     protected \DateTimeInterface $lastCommitTime;
@@ -146,6 +148,16 @@ class AvailableOpensourcePluginEntity extends Entity
     public function setAvailableVersion(string $availableVersion): void
     {
         $this->availableVersion = $availableVersion;
+    }
+
+    public function getPackagistDownloads(): int
+    {
+        return $this->packagistDownloads;
+    }
+
+    public function setPackagistDownloads(int $packagistDownloads): void
+    {
+        $this->packagistDownloads = $packagistDownloads;
     }
 
     public function getPluginId(): ?string

--- a/src/Migration/Migration1743939491AddPackagistDownloads.php
+++ b/src/Migration/Migration1743939491AddPackagistDownloads.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace NuonicPluginInstaller\Migration;
+
+use Doctrine\DBAL\Connection;
+use Shopware\Core\Framework\Migration\MigrationStep;
+
+/**
+ * @internal
+ */
+class Migration1743939491AddPackagistDownloads extends MigrationStep
+{
+    public function getCreationTimestamp(): int
+    {
+        return 1743939491;
+    }
+
+    public function update(Connection $connection): void
+    {
+        $connection->executeStatement('ALTER TABLE `nuonic_available_opensource_plugin` ADD COLUMN `packagist_downloads` INT(11) NOT NULL AFTER `available_version`');
+    }
+}

--- a/src/Resources/app/administration/src/component/nuonic-extension-card/nuonic-extension-card.html.twig
+++ b/src/Resources/app/administration/src/component/nuonic-extension-card/nuonic-extension-card.html.twig
@@ -22,6 +22,10 @@
 				{{ $tc('nuonic-plugin-installer.cards.license') }}
 				{{ extension.license }}
 			</span>
+			<br />
+			<a :href="'https://packagist.org/packages/' + extension.packageName + '/stats'" target="_blank" class="nuonic-extension-card-base__info-downloads">
+				{{ $tc('nuonic-plugin-installer.cards.downloads') }} {{ extension.packagistDownloads }}
+			</a>
 		</section>
 	</div>
 

--- a/src/Resources/app/administration/src/component/nuonic-extension-card/nuonic-extension-card.scss
+++ b/src/Resources/app/administration/src/component/nuonic-extension-card/nuonic-extension-card.scss
@@ -39,6 +39,10 @@
 		.nuonic-extension-card-base__info-inactive {
 			font-size: $font-size-xs;
 		}
+
+		.nuonic-extension-card-base__info-downloads {
+			font-size: $font-size-xxs;
+		}
 	}
 
 	.nuonic-extension-card-base__main-action {

--- a/src/Resources/app/administration/src/module/nuonic-plugin-installer/page/nuonic-plugin-installer-list/index.js
+++ b/src/Resources/app/administration/src/module/nuonic-plugin-installer/page/nuonic-plugin-installer-list/index.js
@@ -17,8 +17,8 @@ Component.register('nuonic-plugin-installer-list', {
 			limit: 25,
 			total: 0,
 			term: null,
-			sortBy: 'name',
-			sortDirection: 'ASC',
+			sortBy: 'packagistDownloads',
+			sortDirection: 'DESC',
 			loading: false,
 		};
 	},

--- a/src/Resources/app/administration/src/snippet/de-DE.json
+++ b/src/Resources/app/administration/src/snippet/de-DE.json
@@ -20,7 +20,8 @@
       "install": "Installieren",
       "lastCommit": "Letzter Commit am:",
       "license": "Lizenz:",
-      "manufacturer": "Hersteller:"
+      "manufacturer": "Hersteller:",
+      "downloads": "Downloads:"
     },
     "notification": {
       "installFailed": "Installation fehlgeschlagen"

--- a/src/Resources/app/administration/src/snippet/en-GB.json
+++ b/src/Resources/app/administration/src/snippet/en-GB.json
@@ -20,7 +20,8 @@
       "install": "Install",
       "lastCommit": "Last commit on:",
       "license": "License:",
-      "manufacturer": "Manufacturer:"
+      "manufacturer": "Manufacturer:",
+      "downloads": "Downloads:"
     },
     "notification": {
       "installFailed": "Installation failed"


### PR DESCRIPTION
Adds the packagist downloads information to the entity so the user has some info how relevant / popular the plugin is.

<img width="994" alt="image" src="https://github.com/user-attachments/assets/a52ea6ec-a957-42e8-8329-34434f369f1d" />

Perhaps we could also add an smartbar with sorting options for the user like:

- Popularity
- Last updated
- Name ASC / DESC
- Manufacturer
- License
- etc